### PR TITLE
Minimise white flash between deleting and replacing nodes in DOM

### DIFF
--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -1496,16 +1496,11 @@ function normalSetup(impl, object, moduleName, flagChecker)
 {
 	object['embed'] = function embed(node, flags)
 	{
-		while (node.lastChild)
-		{
-			node.removeChild(node.lastChild);
-		}
-
 		return _elm_lang$core$Native_Platform.initialize(
 			flagChecker(impl.init, flags, node),
 			impl.update,
 			impl.subscriptions,
-			normalRenderer(node, impl.view)
+			normalRenderer(node, impl.view, true)
 		);
 	};
 
@@ -1515,18 +1510,24 @@ function normalSetup(impl, object, moduleName, flagChecker)
 			flagChecker(impl.init, flags, document.body),
 			impl.update,
 			impl.subscriptions,
-			normalRenderer(document.body, impl.view)
+			normalRenderer(document.body, impl.view, false)
 		);
 	};
 }
 
-function normalRenderer(parentNode, view)
+function normalRenderer(parentNode, view, removeChildren)
 {
 	return function(tagger, initialModel)
 	{
 		var eventNode = { tagger: tagger, parent: undefined };
 		var initialVirtualNode = view(initialModel);
 		var domNode = render(initialVirtualNode, eventNode);
+		if (removeChildren) {
+			while (parentNode.lastChild)
+			{
+				parentNode.removeChild(parentNode.lastChild);
+			}
+		}
 		parentNode.appendChild(domNode);
 		return makeStepper(domNode, view, initialVirtualNode, eventNode);
 	};


### PR DESCRIPTION
This improves the visual smoothness of hand-over between static
rendered HTML and dynamic HTML that is produced by Elm.

Currently, if we have a large amount of statically generated HTML
which is replaced by a large amount of HTML rendered by Elm, on
running `App.Main.embed` there will be noticeable period between
the old static content getting removed and the new content being
added. Depending on the styling this can result in the appearance
of a "white flash".

This commit does the absolute minimum to bring the removal and addition
closer together so that the white flash is minimised. There are further
optimisations that could be done. For instance, we could in the
case of a single child use `node.replaceChild` instead of
`node.removeChild` followed by `node.appendChild`.

At https://github.com/mlandauer/elm-test-handover there's a very simple elm app which
demonstrates the issue. This is what happens now:
![white-flash-before](https://cloud.githubusercontent.com/assets/2221/25562270/5a78de0a-2dc4-11e7-9404-c4a7bc45fa70.gif)

The red box is static HTML content which is then replaced by the nearly identical green box rendered by Elm. There is a short period between where there is nothing rendered (the white flash).

Here you can see the effect of this patch.
![white-flash-after](https://cloud.githubusercontent.com/assets/2221/25562269/5a76defc-2dc4-11e7-8b03-9d7a55a5998a.gif)

The white flash between the red and green box has gone.
