### PR TITLE
Fix #132: Correctly handles empty strings as values of attributes

### DIFF
--- a/src/Elm/Kernel/VirtualDom.js
+++ b/src/Elm/Kernel/VirtualDom.js
@@ -522,7 +522,7 @@ function _VirtualDom_applyAttrs(domNode, attrs)
 	for (var key in attrs)
 	{
 		var value = attrs[key];
-		value
+		typeof value !== 'undefined'
 			? domNode.setAttribute(key, value)
 			: domNode.removeAttribute(key);
 	}
@@ -541,7 +541,7 @@ function _VirtualDom_applyAttrsNS(domNode, nsAttrs)
 		var namespace = pair.__namespace;
 		var value = pair.__value;
 
-		value
+		typeof value !== 'undefined'
 			? domNode.setAttributeNS(namespace, key, value)
 			: domNode.removeAttributeNS(namespace, key);
 	}


### PR DESCRIPTION
The only caller seems to be _VirtualDom_applyFacts, which passes
through a value of 'undefined' for attributes and namespaced attributes.
Set by line 900-903 in _VirtualDom_diffFacts.
