### PR TITLE
Only divert href to app if there is an href for an anchor tag.

### DIFF
--- a/src/Elm/Kernel/VirtualDom.js
+++ b/src/Elm/Kernel/VirtualDom.js
@@ -455,7 +455,7 @@ function _VirtualDom_render(vNode, eventNode)
 		? _VirtualDom_doc.createElementNS(vNode.__namespace, vNode.__tag)
 		: _VirtualDom_doc.createElement(vNode.__tag);
 
-	if (_VirtualDom_divertHrefToApp && vNode.__tag == 'a')
+	if (_VirtualDom_divertHrefToApp && vNode.__tag == 'a' && typeof vNode.d.href !== 'undefined')
 	{
 		domNode.addEventListener('click', _VirtualDom_divertHrefToApp(domNode));
 	}


### PR DESCRIPTION
Addresses issue raised at https://github.com/elm/browser/issues/34 which appears to check out, when you take a look at the HTML specification.