### PR TITLE
Fix which `key` is used in swapping nodes in diffKeyedKids

### DIFF
--- a/src/Elm/Kernel/VirtualDom.js
+++ b/src/Elm/Kernel/VirtualDom.js
@@ -1045,11 +1045,11 @@ function _VirtualDom_diffKeyedKids(xParent, yParent, patches, rootIndex)
 		{
 			index++;
 			_VirtualDom_diffHelp(xNode, yNextNode, localPatches, index);
-			_VirtualDom_insertNode(changes, localPatches, xKey, yNode, yIndex, inserts);
+			_VirtualDom_insertNode(changes, localPatches, yKey, yNode, yIndex, inserts);
 			index += xNode.__descendantsCount || 0;
 
 			index++;
-			_VirtualDom_removeNode(changes, localPatches, xKey, xNextNode, index);
+			_VirtualDom_removeNode(changes, localPatches, yKey, xNextNode, index);
 			index += xNextNode.__descendantsCount || 0;
 
 			xIndex += 2;


### PR DESCRIPTION
I think I've found a semantic bug in _VirtualDom_diffKeyedKids function. It doesn't seem to affect anything, so it's probably fine as is, but I thought this would still be interesting.

Consider this:
x is `A B C D`
y is `A C B D`

B is a new match and the xNode and yNextNode
C is an old match and the yNode and xNextNode

yNode == xNode

We first diff x's B and y's B `_VirtualDom_diffHelp(xNode, yNextNode, localPatches, index);`
Then we insert y's C (yNode)
Then we remove the x's C (xNextNode)

When we do the insert/remove of C we should be using yKey (or xNextKey) because that is what C's key is.

With all that being said,

This is only a semantic bug. The code works fine because since xKey is used in both places it becomes a Move like it would otherwise.