### PR TITLE
Fix codeblock for capture-vs-bubble ASCII diagram

### DIFF
--- a/hints/capture-vs-bubble.md
+++ b/hints/capture-vs-bubble.md
@@ -1,6 +1,7 @@
 Events flow through the DOM in two phases:
 
 <span style="font-family:'Courier New',Courier;">
+
 ```
     Capture     Bubble
        ↓          ↑
@@ -14,6 +15,7 @@ Events flow through the DOM in two phases:
 │ └────────────────────┘ │
 └────────────────────────┘
 ```
+
 </span>
 
 In the old times, Microsoft only had `Bubble` and Netscape only had `Capture`. It was not ideal.


### PR DESCRIPTION
- Previously wasn't rendering the diagram in the markdown code blocks properly.
    - Was missing empty lines before/after the codeblock ticks (```)