### PR TITLE
Set value property before selectionEnd and selectionStart

### DIFF
--- a/src/Elm/Kernel/VirtualDom.js
+++ b/src/Elm/Kernel/VirtualDom.js
@@ -477,8 +477,13 @@ function _VirtualDom_render(vNode, eventNode)
 
 function _VirtualDom_applyFacts(domNode, eventNode, facts)
 {
+	// value has to be set before selectionStart and selectionEnd, or they'll conflict
+	if ('value' in facts) {
+		domNode['value'] = facts['value']
+	}
 	for (var key in facts)
 	{
+		if (key === 'value') continue
 		var value = facts[key];
 
 		key === 'a__1_STYLE'
@@ -909,7 +914,7 @@ function _VirtualDom_diffFacts(x, y, category)
 		var yValue = y[xKey];
 
 		// reference equal, so don't worry about it
-		if (xValue === yValue && xKey !== 'value' && xKey !== 'checked'
+		if (xValue === yValue && xKey !== 'value' && xKey !== 'checked' && xKey !== 'selectionEnd' && xKey !== 'selectionStart'
 			|| category === 'a__1_EVENT' && _VirtualDom_equalEvents(xValue, yValue))
 		{
 			continue;


### PR DESCRIPTION
Changing the `value` property of a `textarea` also [implicitly changes (step 4)](https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-value) its `selectionEnd` and `selectionStart` properties. Since virtual-dom isn't aware of this, the in-memory copy of the dom now differs from the real dom in these properties, leading to bugs.

Adding the logic to handle this properly requires handling a lot of edge cases, so I couldn't find a nice way to implement it considering that these properties are uncommon and code size is important, hence this hotfix.

This hotfix always considers the `selectionStart` and `selectionEnd` properties modified, like we already do with `value` and `checked`. Setting these properties to themselves (moving the cursor/selection to where it already is) is idempotent so this should be safe.

I've tested this patch by modifying the js output by the compiler.