### PR TITLE
Fixes #103 Html.map + blur event on DOM removal makes impossible states possible

### DIFF
--- a/src/Elm/Kernel/VirtualDom.js
+++ b/src/Elm/Kernel/VirtualDom.js
@@ -574,6 +574,10 @@ function _VirtualDom_applyEvents(domNode, eventNode, events)
 			if (oldHandler.$ === newHandler.$)
 			{
 				oldCallback.__handler = newHandler;
+				oldCallback.__eventNode = {
+					__tagger: eventNode.__tagger,
+					__parent: eventNode.__parent
+				};
 				continue;
 			}
 			domNode.removeEventListener(key, oldCallback);
@@ -633,7 +637,7 @@ function _VirtualDom_makeCallback(eventNode, initialHandler)
 		var currentEventNode = (
 			stopPropagation && event.stopPropagation(),
 			(tag == 2 ? value.b : tag == 3 && value.__$preventDefault) && event.preventDefault(),
-			eventNode
+			callback.__eventNode
 		);
 		var tagger;
 		var i;
@@ -656,6 +660,7 @@ function _VirtualDom_makeCallback(eventNode, initialHandler)
 	}
 
 	callback.__handler = initialHandler;
+	callback.__eventNode = { __tagger: eventNode.__tagger, __parent: eventNode.__parent };
 
 	return callback;
 }


### PR DESCRIPTION
Updated SSCCE: https://ellie-app.com/8cPfM8xMj7Za1

This issue happens in chrome, and not firefox (as mentioned on #103). To see the issue on the SSCCE above:
* press "Go to B"
* look at the Logs
* impossible message `MsgB BlurA` triggered by the blur event

More details about the problem can be found on #103.