### PR TITLE
Use Object.create(null) instead of {} to compute keyed diffs

### DIFF
--- a/src/Elm/Kernel/VirtualDom.js
+++ b/src/Elm/Kernel/VirtualDom.js
@@ -981,7 +981,7 @@ function _VirtualDom_diffKeyedKids(xParent, yParent, patches, rootIndex)
 {
 	var localPatches = [];
 
-	var changes = {}; // Dict String Entry
+	var changes = Object.create(null); // Dict String Entry
 	var inserts = []; // Array { index : Int, entry : Entry }
 	// type Entry = { tag : String, vnode : VNode, index : Int, data : _ }
 


### PR DESCRIPTION
This is a minor improvement pull request.

`{}` creates an empty object but which still contains methods and properties like `toString`. Checking `changes[key]` when the key is for instance `toString` creates false positives in that check.

I was looking whether into whether this caused bugs, but in practice, the algorithms in `_VirtualDom_insertNode` and `_VirtualDom_removeNode` end up with the correct behavior because they recurse with a modified key, but do so with an unnecessary iteration.

[`Object.create(null)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create#custom_and_null_objects) creates an empty object without any methods or properties, leading to no false positives and one less unnecessary iteration.