### PR TITLE
Chrome extensions (Grammarly in our case) cause runtime errors

### DIFF
--- a/src/Elm/Kernel/VirtualDom.js
+++ b/src/Elm/Kernel/VirtualDom.js
@@ -434,7 +434,9 @@ function _VirtualDom_render(vNode, eventNode)
 
 	if (tag === __2_TEXT)
 	{
-		return _VirtualDom_doc.createTextNode(vNode.__text);
+		var n = _VirtualDom_doc.createTextNode(vNode.__text);
+		n.created_by_elm = true;
+		return n
 	}
 
 	if (tag === __2_TAGGER)
@@ -469,6 +471,7 @@ function _VirtualDom_render(vNode, eventNode)
 	var domNode = vNode.__namespace
 		? _VirtualDom_doc.createElementNS(vNode.__namespace, vNode.__tag)
 		: _VirtualDom_doc.createElement(vNode.__tag);
+	domNode.created_by_elm = true;
 
 	if (_VirtualDom_divertHrefToApp && vNode.__tag == 'a')
 	{
@@ -1328,14 +1331,52 @@ function _VirtualDom_addDomNodesHelp(domNode, vNode, patches, i, low, high, even
 
 	var vKids = vNode.__kids;
 	var childNodes = domNode.childNodes;
-	for (var j = 0; j < vKids.length; j++)
+	for (var j = 0, k = 0; j < Math.max(vKids.length, childNodes.length); j++, k++)
 	{
 		low++;
 		var vKid = tag === __2_NODE ? vKids[j] : vKids[j].b;
 		var nextLow = low + (vKid.__descendantsCount || 0);
+
+		// The following 1-4 are added to avoid runtime errors due to browser extensions.
+		// This logic assumes that insertion and replacement do not occur at the same time.
+
+		// 1. if unknown nodes have been inserted, skip them
+		if(childNodes.length > vKids.length)
+		{
+			while(!childNodes[k].created_by_elm)
+			{
+				k++
+			}
+		}
+		// 2. if existing node has been removed, restore it from the old vnode
+		if(childNodes.length < vKids.length)
+		{
+			if(childNodes[k])
+			{
+				_VirtualDom_applyPatchRedraw(childNodes[k], vKids[j], eventNode)
+			}
+			else
+			{
+				domNode.appendChild(_VirtualDom_render(vKids[j], eventNode));
+			}
+		}
+		// 3. if existing node has been replaced, restore it from the old vnode
+		if(childNodes.length === vKids.length)
+		{
+			if(!childNodes[k].created_by_elm)
+			{
+				_VirtualDom_applyPatchRedraw(childNodes[k], vKids[j], eventNode)
+			}
+		}
+		// 4. final check for some edge cases
+		if(vKids[j].$ === __2_NODE && (childNodes[k].tagName || "").toLowerCase() !== vKids[j].__tag)
+		{
+			_VirtualDom_applyPatchRedraw(childNodes[k], vKids[j], eventNode)
+		}
+
 		if (low <= index && index <= nextLow)
 		{
-			i = _VirtualDom_addDomNodesHelp(childNodes[j], vKid, patches, i, low, nextLow, eventNode);
+			i = _VirtualDom_addDomNodesHelp(childNodes[k], vKid, patches, i, low, nextLow, eventNode);
 			if (!(patch = patches[i]) || (index = patch.__index) > high)
 			{
 				return i;
@@ -1408,6 +1449,25 @@ function _VirtualDom_applyPatch(domNode, patch)
 
 		case __3_REMOVE_LAST:
 			var data = patch.__data;
+			
+			// Added to avoid runtime errors due to browser extensions.
+			if(domNode.childNodes.length !== data.__diff + data.__length)
+			{
+				var removed = 0;
+				var index = domNode.childNodes.length - 1;
+				while (removed < data.__diff)
+				{
+					var childNode = domNode.childNodes[index];
+					if(childNode.created_by_elm)
+					{
+						domNode.removeChild(childNode);
+						removed++;
+					}
+					index--;
+				}
+				return domNode;
+			}
+
 			for (var i = 0; i < data.__diff; i++)
 			{
 				domNode.removeChild(domNode.childNodes[data.__length]);
@@ -1525,6 +1585,8 @@ function _VirtualDom_applyPatchReorderEndInsertsHelp(endInserts, patch)
 
 function _VirtualDom_virtualize(node)
 {
+	node.created_by_elm = true;
+
 	// TEXT NODES
 
 	if (node.nodeType === 3)


### PR DESCRIPTION
[This PR is a re-posting of this fix](https://discourse.elm-lang.org/t/runtime-errors-caused-by-chrome-extensions/4381/15)
These patches fix the issue below.

<img width="1148" alt="Screen Shot 2022-06-10 at 8 01 24 AM" src="https://user-images.githubusercontent.com/10421138/173072921-80634dbe-0b54-4aab-91d7-0eb7907c185a.png">

Here's the expanded stack trace.
```
Main.elm:3676 Uncaught TypeError: Cannot read properties of undefined (reading 'childNodes')
    at _VirtualDom_addDomNodesHelp (Main.elm:3676:1)
    at _VirtualDom_addDomNodesHelp (Main.elm:3684:1)
    at _VirtualDom_addDomNodesHelp (Main.elm:3684:1)
    at _VirtualDom_addDomNodesHelp (Main.elm:3684:1)
    at _VirtualDom_addDomNodesHelp (Main.elm:3684:1)
    at _VirtualDom_addDomNodesHelp (Main.elm:3670:1)
    at _VirtualDom_addDomNodesHelp (Main.elm:3684:1)
    at _VirtualDom_addDomNodes (Main.elm:3600:1)
    at _VirtualDom_applyPatches (Main.elm:3707:1)
    at Main.elm:4081:1
_VirtualDom_addDomNodesHelp @ Main.elm:3676
_VirtualDom_addDomNodesHelp @ Main.elm:3684
_VirtualDom_addDomNodesHelp @ Main.elm:3684
_VirtualDom_addDomNodesHelp @ Main.elm:3684
_VirtualDom_addDomNodesHelp @ Main.elm:3684
_VirtualDom_addDomNodesHelp @ Main.elm:3670
_VirtualDom_addDomNodesHelp @ Main.elm:3684
_VirtualDom_addDomNodes @ Main.elm:3600
_VirtualDom_applyPatches @ Main.elm:3707
(anonymous) @ Main.elm:4081
updateIfNeeded @ Main.elm:4615
requestAnimationFrame (async)
updateIfNeeded @ Main.elm:4615
requestAnimationFrame (async)
updateIfNeeded @ Main.elm:4615
requestAnimationFrame (async)
updateIfNeeded @ Main.elm:4615
requestAnimationFrame (async)
updateIfNeeded @ Main.elm:4615
requestAnimationFrame (async)
updateIfNeeded @ Main.elm:4615
requestAnimationFrame (async)
updateIfNeeded @ Main.elm:4615
requestAnimationFrame (async)
updateIfNeeded @ Main.elm:4615
requestAnimationFrame (async)
updateIfNeeded @ Main.elm:4615
requestAnimationFrame (async)
(anonymous) @ Main.elm:4626
sendToApp @ Main.elm:1885
(anonymous) @ Main.elm:1994
_Scheduler_step @ Main.elm:1810
_Scheduler_enqueue @ Main.elm:1784
_Scheduler_rawSpawn @ Main.elm:1715
(anonymous) @ Main.elm:5394
setInterval (async)
(anonymous) @ Main.elm:5394
_Scheduler_step @ Main.elm:1810
_Scheduler_enqueue @ Main.elm:1784
_Scheduler_rawSend @ Main.elm:1730
_Platform_dispatchEffects @ Main.elm:2102
_Platform_enqueueEffects @ Main.elm:2088
_Platform_initialize @ Main.elm:1889
(anonymous) @ Main.elm:4052
(anonymous) @ Main.elm:20
./elm/src/index.js @ index.js:19
__webpack_require__ @ bootstrap:19
__webpack_exec__ @ bootstrap.mackey.css:1
(anonymous) @ bootstrap.mackey.css:1
__webpack_require__.O @ chunk loaded:23
(anonymous) @ bootstrap.mackey.css:1
webpackJsonpCallback @ jsonp chunk loading:71
(anonymous) @ init-main.b89ac79a8ec35153daba.js:1
```

More info:
https://github.com/elm/virtual-dom/pull/177#issuecomment-1125291829

Currently we've solved for this by patching virtual-dom with an outdated / seemingly unmaintained [shell script call `shelm`](https://github.com/robx/shelm).

Unfortunately, `elm-json` doesn't like the `"locations"` key that `shelm` depends on to do it's overriding so every time we install or update packages that `"locations"` key gets deleted and the developer has to remember to bring it back after an install. 

This means recently we accidentally re-introduced this Grammarly bug into a production release.

Secondarily, using `shelm` means that our LSP tooling using `~/.elm` gets out of sync with what `shelm` uses for our local packages sometimes breaking intellisense.

Merging this fix means
1.  we can remove the hacky shell script that's overriding this for us in our production builds and alleviate the incompatibility with other elm ecosystem tooling.
2. It fixes potential issues with Grammarly for other people in the elm community that I know [have been affected by this issue](https://discourse.elm-lang.org/t/runtime-errors-caused-by-chrome-extensions/4381). 
3. The patch apparently fixes issues for other "Chrome Extensions" altho we don't have any users using any of the other extensions that might also be breaking elm/virtual-dom.
